### PR TITLE
Support the storage of final, predicted metrics (#7)

### DIFF
--- a/monitoring-data-persistor/src/main/runtime/DataPersistor.py
+++ b/monitoring-data-persistor/src/main/runtime/DataPersistor.py
@@ -78,6 +78,8 @@ class GenericConsumerHandler(Handler):
                     if (application_name in self.application_consumer_handler_connectors.keys()):
                         self.application_consumer_handler_connectors[application_name].stop()
                     logging.info("Attempting to register new connector...")
+                    application_handler = ConsumerHandler(application_name=application_name)
+                    
                     self.application_consumer_handler_connectors[application_name] = exn.connector.EXN(
                         Constants.data_persistor_name + "-" + application_name, handler=Bootstrap(),
                         consumers=[
@@ -86,14 +88,13 @@ class GenericConsumerHandler(Handler):
                                                    application=application_name,
                                                    topic=True,
                                                    fqdn=True,
-                                                   handler=ConsumerHandler(application_name=application_name)
-                                                   ),
+                                                   handler=application_handler),
                             core.consumer.Consumer('monitoring-data-persistor-predicted'+application_name,
                                                    Constants.monitoring_broker_topic + '.predicted.>',
                                                    application=application_name,
                                                    topic=True,
                                                    fqdn=True,
-                                                   handler=ConsumerHandler(application_name=application_name)
+                                                   handler=application_handler
                                                    )
                         ],
                         url=Constants.broker_ip,

--- a/monitoring-data-persistor/src/main/runtime/DataPersistor.py
+++ b/monitoring-data-persistor/src/main/runtime/DataPersistor.py
@@ -81,16 +81,16 @@ class GenericConsumerHandler(Handler):
                     self.application_consumer_handler_connectors[application_name] = exn.connector.EXN(
                         Constants.data_persistor_name + "-" + application_name, handler=Bootstrap(),
                         consumers=[
-                            core.consumer.Consumer('monitoring-'+application_name,
+                            core.consumer.Consumer('monitoring-data-persistor-realtime'+application_name,
                                                    Constants.monitoring_broker_topic + '.realtime.>',
                                                    application=application_name,
                                                    topic=True,
                                                    fqdn=True,
                                                    handler=ConsumerHandler(application_name=application_name)
                                                    ),
-                            core.consumer.Consumer('monitoring-'+application_name,
+                            core.consumer.Consumer('monitoring-data-persistor-predicted'+application_name,
                                                    Constants.monitoring_broker_topic + '.predicted.>',
-                                                   application="",
+                                                   application=application_name,
                                                    topic=True,
                                                    fqdn=True,
                                                    handler=ConsumerHandler(application_name=application_name)

--- a/monitoring-data-persistor/src/main/runtime/DataPersistor.py
+++ b/monitoring-data-persistor/src/main/runtime/DataPersistor.py
@@ -38,7 +38,7 @@ class ConsumerHandler(Handler):
                 logging.info("Writing new real-time monitoring data to Influx DB")
                 self.influx_connector.write_data(point,self.application_name)
             elif ((str(address).split(".")[-2]) == "predicted"):
-                point = Point("_predicted_"+str(address).split(".")[-1]).field("metricValue",body["metricValue"]).tag("level",body["level"]).tag("application_name",self.application_name)
+                point = Point("_predicted_"+str(address).split(".")[-1]).field("metricValue",body["metricValue"]).tag("probability",body["probability"]).tag("predictionTime",body["predictionTime"]).tag("confidence_interval",body["confidence_interval"]).tag("application_name",self.application_name)
                 point.time(body["timestamp"],write_precision=WritePrecision.MS)
                 logging.info("Writing new predicted monitoring data to Influx DB")
                 self.influx_connector.write_data(point,self.application_name)

--- a/monitoring-data-persistor/src/main/runtime/InfluxDBConnector.py
+++ b/monitoring-data-persistor/src/main/runtime/InfluxDBConnector.py
@@ -91,6 +91,7 @@ class InfluxDBConnector:
             self.bucket_name = get_influxdb_bucket(application_name)
             self.applications_with_influxdb_bucket_created.append(application_name)
         else:
+            #self.bucket_name = get_influxdb_bucket(application_name)            
             logging.info("The influxdb bucket was reported as created")
         logging.info(f"The data point is {data}")
         self.write_api.write(bucket=self.bucket_name, org=Constants.influxdb_organization_name, record=data, write_precision=WritePrecision.S)


### PR DESCRIPTION
* Reconcile repositories

Change-Id: I5651affc68165e1739d145f97fb68c7e5d1979cc

* Timestamp fix

Change-Id: Ib537b56bc075de29e3e369349152a3269c6d3e38

* Improved the robustness of the component

Better handling of metric_list messages with an identical version

Improved the robustness of the component in case of a broker connector failure

Change-Id: I79480b1cebc769d1ea09ba6d17f75f535e5c1569

* Support the storage of predicted metrics

Change-Id: I6b15c4bb33c1bd6739890756b06d27060ac5fb56